### PR TITLE
Add --index-file option

### DIFF
--- a/ratarmount.py
+++ b/ratarmount.py
@@ -213,6 +213,7 @@ class SQLiteIndexedTar:
         fileObject                 = None,
         writeIndex                 = False,
         clearIndexCache            = False,
+        indexFileName              = None,
         recursive                  = False,
         gzipSeekPointSpacing       = 4*1024*1024,
         encoding                   = tarfile.ENCODING,
@@ -271,7 +272,7 @@ class SQLiteIndexedTar:
             SQLiteIndexedTar._openCompressedFile( fileObject, gzipSeekPointSpacing, encoding )
 
         # will be used for storing indexes if current path is read-only
-        possibleIndexFilePaths = [
+        possibleIndexFilePaths = [indexFileName] if indexFileName is not None else [
             self.tarFileName + ".index.sqlite",
             os.path.expanduser( os.path.join( "~", ".ratarmount",
                                               self.tarFileName.replace( "/", "_" ) + ".index.sqlite" ) )
@@ -1648,6 +1649,11 @@ version, you can simply do:
                'The index needs to be (re)created to apply this option!' )
 
     parser.add_argument(
+        '--index-file', type = str,
+        help = 'Specify a path to the .index.sqlite file.')
+
+
+    parser.add_argument(
         '-o', '--fuse', type = str, default = '',
         help = 'Comma separated FUSE options. See "man mount.fuse" for help. '
                'Example: --fuse "allow_other,entry_timeout=2.8,gid=0". ' )
@@ -1735,6 +1741,7 @@ def cli( args = None ):
         ignoreZeros                = args.ignore_zeros,
         verifyModificationTime     = args.verify_mtime,
         stripRecursiveTarExtension = args.strip_recursive_tar_extension,
+        indexFileName              = args.index_file,
     )
 
     fuse.FUSE( operations = fuseOperationsObject,


### PR DESCRIPTION
My use case: I'd like to distribute the index file along with my
ratarmount setup script, because then the setup time is nearly zero
(because it doesn't need to build the sqlite cache).

To facilitiate this, it's very convenient to have a way of specifying
the full path to the index file. That way I can simply bundle the
file with my program.

It's true that I could theoretically copy the file to the right place
underneath `~/.ratarmount`, but that's much more complicated.