### PR TITLE
Adding support for xz

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,11 @@ python:
 
 before_install:
   - sudo apt-get update
-  - sudo apt-get -y install bzip2 pbzip2 xz-utils # necessary for tests
+  - sudo apt-get -y install bzip2 pbzip2 xz-utils zstd # necessary for tests
 
 install:
   - pip install --upgrade-strategy eager --upgrade cython twine pylint
+  - pip install git+https://github.com/martinellimarco/indexed_zstd
 
 script:
   # test whether installation from tarball works

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ python:
 before_install:
   - sudo apt-get update
   - sudo apt-get -y install bzip2 pbzip2 xz-utils zstd # necessary for tests
-  - sudo apt-get -y install libzstd-dev g++ # todo remove after having pre-built wheels for all targets
 
 install:
   - pip install --upgrade-strategy eager --upgrade cython twine pylint

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ python:
 
 before_install:
   - sudo apt-get update
-  - sudo apt-get -y install bzip2 pbzip2 # necessary for tests
+  - sudo apt-get -y install bzip2 pbzip2 xz-utils # necessary for tests
 
 install:
   - pip install --upgrade-strategy eager --upgrade cython twine pylint

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - sudo apt-get -y install bzip2 pbzip2 # necessary for tests
 
 install:
-  - pip install --upgrade cython twine
+  - pip install --upgrade-strategy eager --upgrade cython twine
 
 script:
   # test whether installation from tarball works

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ python:
 before_install:
   - sudo apt-get update
   - sudo apt-get -y install bzip2 pbzip2 xz-utils zstd # necessary for tests
+  - sudo apt-get -y install libzstd-dev g++ # todo remove after having pre-built wheels for all targets
 
 install:
   - pip install --upgrade-strategy eager --upgrade cython twine pylint

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ python:
   - 3.6
   - 3.7
   - 3.8
+  - 3.9
 
 before_install:
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 
 os: linux
+dist: focal
 
 git:
   depth: 3
@@ -19,7 +20,6 @@ before_install:
 
 install:
   - pip install --upgrade-strategy eager --upgrade cython twine pylint
-  - pip install git+https://github.com/martinellimarco/indexed_zstd
 
 script:
   # test whether installation from tarball works

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - sudo apt-get -y install bzip2 pbzip2 # necessary for tests
 
 install:
-  - pip install --upgrade-strategy eager --upgrade cython twine
+  - pip install --upgrade-strategy eager --upgrade cython twine pylint
 
 script:
   # test whether installation from tarball works

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+# Version 0.7.0 built on 2020-12-xx
+
+ - Add CLI option to specify an index location.
+ - Add support for xz compressed TARs using the lzmaffi Python module.
+
 # Version 0.6.1 built on 2020-10-02
 
  - Fix broken CLI and add test for it.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Downloads](https://pepy.tech/badge/ratarmount/month)](https://pepy.tech/project/ratarmount/month)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](http://opensource.org/licenses/MIT)
 [![Build Status](https://travis-ci.org/mxmlnkn/ratarmount.svg?branch=master)](https://travis-ci.com/mxmlnkn/ratarmount)
+[![Discord](https://img.shields.io/discord/783411320354766878?label=discord)](https://discord.gg/Wra6t6akh2)
+[![Telegram](https://img.shields.io/badge/Chat-Telegram-%2330A3E6)](https://t.me/joinchat/FUdXxkXIv6c4Ib8bgaSxNg)
 
 Combines the random access indexing idea from [tarindexer](https://github.com/devsnd/tarindexer) and then **mounts** the **TAR** using [fusepy](https://github.com/fusepy/fusepy) for easy read-only access just like [archivemount](https://github.com/cybernoid/archivemount/).
 It also will mount TARs inside TARs inside TARs, ... **recursively** into folders of the same name, which is useful for the ImageNet data set.
@@ -24,16 +26,12 @@ You can simply install it from PyPI:
 pip install ratarmount
 ```
 
-Or, if you want to test the latest development version on a Debian-like system:
+Or, if you want to test the latest version:
 ```bash
-sudo apt-get update
-sudo apt-get install python3 python3-pip git
-git clone https://github.com/mxmlnkn/ratarmount.git
-python3 -m pip install --user .
-ratarmount --help
+pip install git+https://github.com/mxmlnkn/ratarmount.git@develop#egginfo=ratarmount
 ```
 
-You can also simply download [ratarmount.py](https://github.com/mxmlnkn/ratarmount/raw/master/ratarmount.py) and call it directly after installing the dependencies manually with: `pip3 install --user fusepy indexed_bzip2`.
+You can also simply download [ratarmount.py](https://github.com/mxmlnkn/ratarmount/raw/master/ratarmount.py) and call it directly after installing the dependencies manually with: `pip3 install --user fusepy indexed_bzip2 indexed_gzip lzmaffi`.
 
 If you want to use other serialization backends instead of the default SQLite one, e.g., because you still have indexes lying around created with those backends and don't want to spend time recreating them, then you'll have to install a version older than 0.5.0 with the optional `legacy-serializers` feature:
 
@@ -237,6 +235,7 @@ Here is a more recent test for version 0.2.0 with the new default SQLite backend
   - Reading a 64kB file: ~4ms
   - Running 'find mountPoint -type f | wc -l' (1.26M stat calls): 1m 50s
 
+
 ## Benchmarks
 
 During the making of this project several benchmarks were created. These can be viewed [here](benchmarks/BENCHMARKS.md).
@@ -247,3 +246,15 @@ These are some of the things benchmarked and compared there:
   - Mounting and file access time comparison between archivemount and ratarmount
 
 ![Benchmark comparison between ratarmount and archivemount](benchmarks/plots/archivemount-comparison.png)
+
+
+## Donations
+
+If ratarmount helped you out and made you so happy that you can't help but want to donate, toss a coin to your programmer through one of these addresses:
+
+| Type | Address                                    |
+|------|--------------------------------------------|
+| BTC  | bc1qkc7stljxazpkk5lzcj4gqu2tvh0dh4exz4563t |
+| ETH  | 0xB6e1809D5C6f52156df7Bd2eE95f586885178c74 |
+| LTC  | LTRbWdUY576MNkhXhXEXNpt3NuY2ecR9F9         |
+| ZEC  | t1bnLeVVub5AzAqj3wV977spttnpa5kdRCm        |

--- a/ratarmount.py
+++ b/ratarmount.py
@@ -374,6 +374,7 @@ class SQLiteIndexedTar:
         # decoding everything. Therefore, do this check only after reading the whole file.
         # ToDo: Extend the API to query the number of frames as that is the only thing needed and "zstd -l" seems
         #       to be able to query the number of frames quickly even when it can't query the uncompressed size.
+        # Ideas: pyzstd.get_frame_size
         if self.compression == 'zstd':
             try:
                 if len( self.tarFileObject.block_offsets ) <= 1:

--- a/ratarmount.py
+++ b/ratarmount.py
@@ -36,7 +36,7 @@ except ImportError:
 import fuse
 
 
-__version__ = '0.6.1'
+__version__ = '0.7.0'
 
 printDebug = 1
 

--- a/ratarmount.py
+++ b/ratarmount.py
@@ -32,6 +32,12 @@ except ImportError:
     print( "[Warning] The indexed_gzip module was not found. Please install it to open gzip compressed TAR files!" )
 
 try:
+    import indexed_zstd
+    from indexed_zstd import IndexedZstdFile
+except ImportError:
+    print( "[Warning] The indexed_zstd module was not found. Please install it to open zstd compressed TAR files!" )
+
+try:
     import lzmaffi
 except ImportError:
     print( "[Warning] The lzmaffi module was not found. Please install it to open xz compressed TAR files!" )
@@ -42,6 +48,28 @@ import fuse
 __version__ = '0.7.0'
 
 printDebug = 1
+
+zstdMultiFrameCompressorBashFunction = """
+function createMultiFrameZstd()
+{
+    local file frameSize fileSize offset
+    file=$1
+    frameSize=$2
+
+    if [[ ! -f "$file" ]]; then echo "Could not find file '$file'" 1>&2; return 1; fi
+    if [[ ! $frameSize =~ ^[0-9]+$ ]]; then echo "Frame size '$frameSize' is not a valid number" 1>&2; fi
+
+    fileSize=$( stat -c %s -- "$file" )
+
+    > "$file.zstd"
+    for (( offset = 0; offset < fileSize; offset += frameSize )); do
+        dd if="$file" bs=$(( 1024*1024 )) iflag=skip_bytes,count_bytes skip="$offset" count="$frameSize" 2>/dev/null |
+            zstdcat --compress --no-progress >> "$file.zstd"
+    done
+}
+
+createMultiFrameZstd <path-to-file-to-compress> $(( 4*1024*1024 ))
+"""
 
 def overrides( parentClass ):
     def overrider( method ):
@@ -232,7 +260,7 @@ class SQLiteIndexedTar:
         tarFileName : Path to the TAR file to be opened. If not specified, a fileObject must be specified.
                       If only a fileObject is given, the created index can't be cached (efficiently).
         fileObject : A io.IOBase derived object. If not specified, tarFileName will be opened.
-                     If it is an instance of IndexedBzip2File or IndexedGzipFile, then the offset
+                     If it is an instance of IndexedBzip2File, IndexedGzipFile, or IndexedZstdFile, then the offset
                      loading and storing from and to the SQLite database is managed automatically by this class.
         encoding : Will be forwarded to tarfile. Specifies how filenames inside the TAR are encoded.
         ignoreZeros : Will be forwarded to tarfile. Specifies to not only skip zero blocks but also blocks with
@@ -278,6 +306,7 @@ class SQLiteIndexedTar:
         self.tarFileObject, self.rawFileObject, self.compression, self.isTar = \
             SQLiteIndexedTar._openCompressedFile( fileObject, gzipSeekPointSpacing, encoding )
 
+        # Fortunately, determining the block boundaries for xz is O(1) because there is an index at the end of the file!
         if self.compression == 'xz':
             try:
                 if len( self.tarFileObject.block_boundaries ) <= 1:
@@ -341,6 +370,24 @@ class SQLiteIndexedTar:
         self.createIndex( self.tarFileObject )
         self._loadOrStoreCompressionOffsets()
 
+        # If the uncompressed sizes are not stored in the zstd (they are optional), getting the offsets requires
+        # decoding everything. Therefore, do this check only after reading the whole file.
+        # ToDo: Extend the API to query the number of frames as that is the only thing needed and "zstd -l" seems
+        #       to be able to query the number of frames quickly even when it can't query the uncompressed size.
+        if self.compression == 'zstd':
+            try:
+                if len( self.tarFileObject.block_offsets ) <= 1:
+                    print( "[Warning] The specified file '{}'".format( self.tarFileName ) )
+                    print( "[Warning] is compressed using zstd but only contains one zstd frame. This makes it " )
+                    print( "[Warning] impossible to use true seeking! Please (re)compress your TAR using multiple " )
+                    print( "[Warning] frames in order for ratarmount to do be able to do fast seeking to requested " )
+                    print( "[Warning] files. Else, each file access will decompress the whole TAR from the beginning!" )
+                    print( "[Warning] Here is a simple bash script demonstrating how to do this:" )
+                    print( zstdMultiFrameCompressorBashFunction )
+                    print()
+            except:
+                pass
+
         self._storeTarMetadata()
 
         if printDebug >= 1 and writeIndex:
@@ -387,6 +434,10 @@ class SQLiteIndexedTar:
             if 'IndexedBzip2File' in globals() and isinstance( fileobj, IndexedBzip2File ):
                 # Note that because bz2 works on a bitstream the tell_compressed returns the offset in bits
                 progressBar.update( fileobj.tell_compressed() // 8 )
+                return
+
+            if 'IndexedZstdFile' in globals() and isinstance( fileobj, IndexedZstdFile ):
+                progressBar.update( fileobj.tell_compressed() )
                 return
 
             if hasattr( fileobj, 'fileobj' ):
@@ -579,7 +630,7 @@ class SQLiteIndexedTar:
         if fileCount == 0:
             tarInfo = os.fstat( fileObject.fileno() )
             fname = os.path.basename( self.tarFileName )
-            for suffix in [ '.gz', '.bz2', '.bzip2', '.gzip', '.xz' ]:
+            for suffix in [ '.gz', '.bz2', '.bzip2', '.gzip', '.xz', '.zstd' ]:
                 if fname.lower().endswith( suffix ) and len( fname ) > len( suffix ):
                     fname = fname[:-len( suffix )]
                     break
@@ -666,6 +717,9 @@ class SQLiteIndexedTar:
 
             if 'IndexedGzipFile' in globals() and isinstance( fileObject, IndexedGzipFile ):
                 versions += [ makeVersionRow( 'indexed_gzip', indexed_gzip.__version__ ) ]
+
+            if 'IndexedZstdFile' in globals() and isinstance( fileObject, IndexedZstdFile ):
+                versions += [ makeVersionRow( 'indexed_zstd', indexed_zstd.__version__ ) ]
 
             self.sqlConnection.executemany( 'INSERT OR REPLACE INTO "versions" VALUES (?,?,?,?,?)', versions )
         except Exception as exception:
@@ -999,7 +1053,7 @@ class SQLiteIndexedTar:
 
                 return isTar, compression
 
-            except tarfile.ReadError:
+            except ( tarfile.ReadError, tarfile.CompressionError ):
                 if oldOffset is not None:
                     fileobj.seek( oldOffset )
 
@@ -1019,6 +1073,36 @@ class SQLiteIndexedTar:
             except:
                 if oldOffset is not None:
                     fileobj.seek( oldOffset )
+
+        # Starting from here, these compressions are not support by tarfile, so we have to check differently
+
+        foundCompression = False
+        for compression in [ 'zstd' ]:
+            if compression == 'zstd' and 'IndexedZstdFile' not in globals():
+                raise Exception( "Can't open a zstd compressed TAR file '{}' without indexed_zstd module!"
+                                 .format( name ) )
+
+            try:
+                # ToDo: Check whether IndexedZstdFile correctly throws on incorrect input
+                compressedFile = IndexedZstdFile( fileobj.fileno() if fileobj else name )
+                compressedFile.block_offsets() # ToDo: AVOID HAVING TO DO THIS!
+                foundCompression = True
+
+                # Simply opening a TAR file should be fast as only the header should be read!
+                tarfile.open( fileobj = compressedFile, mode = 'r:', encoding = encoding )
+                isTar = True
+
+                if oldOffset is not None:
+                    fileobj.seek( oldOffset )
+
+                return isTar, compression
+
+            except ( tarfile.ReadError, tarfile.CompressionError ):
+                if oldOffset is not None:
+                    fileobj.seek( oldOffset )
+
+                if foundCompression:
+                    return isTar, compression
 
         raise Exception( "File '{}' does not seem to be a valid TAR file!".format( name ) )
 
@@ -1041,6 +1125,12 @@ class SQLiteIndexedTar:
         elif compression == 'xz':
             rawFile = tarFile # save so that garbage collector won't close it!
             tarFile = lzmaffi.open( rawFile )
+        elif compression == 'zstd':
+            rawFile = tarFile # save so that garbage collector won't close it!
+            tarFile = IndexedZstdFile( rawFile.fileno() )
+            # Currently, block_offsets has to be called to ensure that the block offsets exist before reading!
+            # ToDo: Refactor indexed_zstd to avoid requiring this.
+            tarFile.block_offsets()
 
         return tarFile, rawFile, compression, isTar
 
@@ -1064,6 +1154,23 @@ class SQLiteIndexedTar:
                     db.execute( 'DROP TABLE bzip2blocks' )
                 db.execute( 'CREATE TABLE bzip2blocks ( blockoffset INTEGER PRIMARY KEY, dataoffset INTEGER )' )
                 db.executemany( 'INSERT INTO bzip2blocks VALUES (?,?)',
+                                fileObject.block_offsets().items() )
+                db.commit()
+            return
+
+        if 'IndexedZstdFile' in globals() and isinstance( fileObject, IndexedZstdFile ):
+            try:
+                offsets = dict( db.execute( 'SELECT blockoffset,dataoffset FROM zstdblocks;' ) )
+                fileObject.set_block_offsets( offsets )
+            except:
+                if printDebug >= 2:
+                    print( "[Info] Could not load zstd block offset data. Will create it from scratch." )
+
+                tables = [ x[0] for x in db.execute( 'SELECT name FROM sqlite_master WHERE type="table";' ) ]
+                if 'zstdblocks' in tables:
+                    db.execute( 'DROP TABLE zstdblocks' )
+                db.execute( 'CREATE TABLE zstdblocks ( blockoffset INTEGER PRIMARY KEY, dataoffset INTEGER )' )
+                db.executemany( 'INSERT INTO zstdblocks VALUES (?,?)',
                                 fileObject.block_offsets().items() )
                 db.commit()
             return
@@ -1545,7 +1652,7 @@ class TarFileType:
             try:
                 tarfile.open( tarFile, mode = self.mode + ':' + compression, encoding = self.encoding )
                 return ( tarFile, compression )
-            except tarfile.ReadError:
+            except ( tarfile.ReadError, tarfile.CompressionError ):
                 pass
 
             try:
@@ -1558,14 +1665,26 @@ class TarFileType:
                 if compression == 'xz':
                     lzmaffi.open( tarFile ).read( 1 )
                     return ( tarFile, compression )
+                if compression == 'zstd':
+                    IndexedZstdFile( tarFile ).read( 1 )
+                    return ( tarFile, compression )
             except:
                 pass
 
         msg = "Archive '{}' can't be opened!\n".format( tarFile )
         msg += "This might happen for xz compressed TAR archives, which currently is not supported.\n"
-        if 'IndexedBzip2File' not in globals() or 'IndexedGzipFile' not in globals():
-            msg += "If you are trying to open a bz2 or gzip compressed file make sure that you have the indexed_bzip2 "\
-                   "and indexed_gzip modules installed."
+        if (
+            'IndexedBzip2File' not in globals() or
+            'IndexedGzipFile' not in globals() or
+            'IndexedZstdFile' not in globals() or
+            'lzmaffi' not in globals()
+        ):
+            msg += "If you are trying to open a compressed file, make sure\n"
+            msg += "that you have the respective modules installed:\n"
+            msg += "   bzip2 : indexed_bzip2\n"
+            msg += "   gzip  : indexed_gzip\n"
+            msg += "   xz    : lzmaffi\n"
+            msg += "   zstd  : indexed_zstd\n"
 
         raise argparse.ArgumentTypeError( msg )
 
@@ -1757,6 +1876,8 @@ version, you can simply do:
         compressions += [ 'bz2' ]
     if 'IndexedGzipFile' in globals():
         compressions += [ 'gz' ]
+    if 'IndexedZstdFile' in globals():
+        compressions += [ 'zstd' ]
     if 'lzmaffi' in globals():
         compressions += [ 'xz' ]
     args.mount_source = [ TarFileType( mode = 'r', compressions = compressions, encoding = args.encoding )( tarFile )[0]

--- a/ratarmount.py
+++ b/ratarmount.py
@@ -7,10 +7,8 @@ import bz2
 import collections
 import gzip
 import io
-import itertools
 import json
 import os
-import pprint
 import re
 import sqlite3
 import stat
@@ -69,7 +67,9 @@ class ProgressBar:
         # Use only a shorter window interval to estimate time.
         # Accounts better for higher speeds in beginning, e.g., caused by caching effects.
         # However, this estimate might vary a lot while the other one stabilizes after some time!
-        eta2 = int( ( time.time() - self.lastUpdateTime ) / ( value - self.lastUpdateValue ) * ( self.maxValue - value ) )
+        eta2 = int( ( time.time() - self.lastUpdateTime )
+                    / ( value - self.lastUpdateValue )
+                    * ( self.maxValue - value ) )
         print( "Currently at position {} of {} ({:.2f}%). "
                "Estimated time remaining with current rate: {} min {} s, with average rate: {} min {} s."
                .format( value, self.maxValue, value / self.maxValue * 100.,
@@ -101,6 +101,7 @@ class StenciledFile(io.BufferedIOBase):
         self.fileobj = fileobj
         self.offsets = [ x[0] for x in stencils ]
         self.sizes   = [ x[1] for x in stencils ]
+        self.offset  = 0
 
         # Calculate cumulative sizes
         self.cumsizes = [ 0 ]
@@ -210,7 +211,8 @@ class SQLiteIndexedTar:
     """
 
     # Names must be identical to the SQLite column headers!
-    FileInfo = collections.namedtuple( "FileInfo", "offsetheader offset size mtime mode type linkname uid gid istar issparse" )
+    FileInfo = collections.namedtuple( "FileInfo",
+                                       "offsetheader offset size mtime mode type linkname uid gid istar issparse" )
 
     def __init__(
         self,
@@ -448,7 +450,7 @@ class SQLiteIndexedTar:
             openedConnection = True
             self._openSqlDb( self.indexFileName if self.indexFileName else ':memory:' )
             tables = self.sqlConnection.execute( 'SELECT name FROM sqlite_master WHERE type = "table";' )
-            if set( [ "files", "filestmp", "parentfolders" ] ).intersection( set( [ t[0] for t in tables ] ) ):
+            if { "files", "filestmp", "parentfolders" }.intersection( { t[0] for t in tables } ):
                 raise Exception( "[Error] The index file {} already seems to contain a table. "
                                  "Please specify --recreate-index." )
             self.sqlConnection.executescript( createTables )
@@ -478,75 +480,84 @@ class SQLiteIndexedTar:
 
         # 3. Iterate over files inside TAR and add them to the database
         try:
-          for tarInfo in loadedTarFile:
-            loadedTarFile.members = []
-            globalOffset = streamOffset + tarInfo.offset_data
-            globalOffsetHeader = streamOffset + tarInfo.offset
-            self._updateProgressBar( progressBar, fileObject )
+            for tarInfo in loadedTarFile:
+                loadedTarFile.members = []
+                globalOffset = streamOffset + tarInfo.offset_data
+                globalOffsetHeader = streamOffset + tarInfo.offset
+                self._updateProgressBar( progressBar, fileObject )
 
-            mode = tarInfo.mode
-            if tarInfo.isdir() : mode |= stat.S_IFDIR
-            if tarInfo.isfile(): mode |= stat.S_IFREG
-            if tarInfo.issym() : mode |= stat.S_IFLNK
-            if tarInfo.ischr() : mode |= stat.S_IFCHR
-            if tarInfo.isfifo(): mode |= stat.S_IFIFO
+                mode = (
+                    tarInfo.mode
+                    | ( stat.S_IFDIR if tarInfo.isdir()  else 0 )
+                    | ( stat.S_IFREG if tarInfo.isfile() else 0 )
+                    | ( stat.S_IFLNK if tarInfo.issym()  else 0 )
+                    | ( stat.S_IFCHR if tarInfo.ischr()  else 0 )
+                    | ( stat.S_IFIFO if tarInfo.isfifo() else 0 )
+                )
 
-            # Add a leading '/' as a convention where '/' represents the TAR root folder
-            # Partly, done because fusepy specifies paths in a mounted directory like this
-            # os.normpath does not delete duplicate '/' at beginning of string!
-            fullPath = pathPrefix + "/" + os.path.normpath( tarInfo.name ).lstrip( '/' )
+                # Add a leading '/' as a convention where '/' represents the TAR root folder
+                # Partly, done because fusepy specifies paths in a mounted directory like this
+                # os.normpath does not delete duplicate '/' at beginning of string!
+                fullPath = pathPrefix + "/" + os.path.normpath( tarInfo.name ).lstrip( '/' )
 
-            # 4. Open contained TARs for recursive mounting
-            tarExtension = '.tar'
-            isTar = False
-            if self.mountRecursively and tarInfo.isfile() and tarInfo.name.endswith( tarExtension ):
-                if self.stripRecursiveTarExtension and len( tarExtension ) > 0 and fullPath.endswith( tarExtension ):
-                    fullPath = fullPath[:-len( tarExtension )]
+                # 4. Open contained TARs for recursive mounting
+                tarExtension = '.tar'
+                isTar = False
+                if self.mountRecursively and tarInfo.isfile() and tarInfo.name.endswith( tarExtension ):
+                    if (
+                        self.stripRecursiveTarExtension
+                        and len( tarExtension ) > 0
+                        and fullPath.endswith( tarExtension )
+                    ):
+                        fullPath = fullPath[:-len( tarExtension )]
 
-                oldPos = fileObject.tell()
-                fileObject.seek( globalOffset )
-                oldPrintName = self.tarFileName
+                    oldPos = fileObject.tell()
+                    fileObject.seek( globalOffset )
+                    oldPrintName = self.tarFileName
 
-                try:
-                    self.tarFileName = tarInfo.name.lstrip( '/' ) # This is for output of the recursive call
-                    # StenciledFile's tell returns the offset inside the file chunk instead of the global one,
-                    # so we have to always communicate the offset of this chunk to the recursive call no matter
-                    # whether tarfile has streaming access or seeking access!
-                    tarFileObject = StenciledFile( fileObject, [ ( globalOffset, tarInfo.size ) ] )
-                    self.createIndex( tarFileObject, progressBar, fullPath, globalOffset )
+                    try:
+                        self.tarFileName = tarInfo.name.lstrip( '/' ) # This is for output of the recursive call
+                        # StenciledFile's tell returns the offset inside the file chunk instead of the global one,
+                        # so we have to always communicate the offset of this chunk to the recursive call no matter
+                        # whether tarfile has streaming access or seeking access!
+                        tarFileObject = StenciledFile( fileObject, [ ( globalOffset, tarInfo.size ) ] )
+                        self.createIndex( tarFileObject, progressBar, fullPath, globalOffset )
 
-                    # if the TAR file contents could be read, we need to adjust the actual
-                    # TAR file's metadata to be a directory instead of a file
-                    mode = ( mode & 0o777 ) | stat.S_IFDIR
-                    if mode & stat.S_IRUSR != 0: mode |= stat.S_IXUSR
-                    if mode & stat.S_IRGRP != 0: mode |= stat.S_IXGRP
-                    if mode & stat.S_IROTH != 0: mode |= stat.S_IXOTH
-                    isTar = True
+                        # if the TAR file contents could be read, we need to adjust the actual
+                        # TAR file's metadata to be a directory instead of a file
+                        mode = (
+                            ( mode & 0o777 )
+                            | stat.S_IFDIR
+                            | ( stat.S_IXUSR if mode & stat.S_IRUSR != 0 else 0 )
+                            | ( stat.S_IXGRP if mode & stat.S_IRGRP != 0 else 0 )
+                            | ( stat.S_IXOTH if mode & stat.S_IROTH != 0 else 0 )
+                        )
+                        isTar = True
 
-                except tarfile.ReadError:
-                    None
+                    except tarfile.ReadError:
+                        pass
 
-                self.tarFileName = oldPrintName
-                del tarFileObject
-                fileObject.seek( oldPos )
+                    self.tarFileName = oldPrintName
+                    del tarFileObject
+                    fileObject.seek( oldPos )
 
-            path, name = fullPath.rsplit( "/", 1 )
-            fileInfo = (
-                path               , # 0
-                name               , # 1
-                globalOffsetHeader , # 2
-                globalOffset       , # 3
-                tarInfo.size       , # 4
-                tarInfo.mtime      , # 5
-                mode               , # 6
-                tarInfo.type       , # 7
-                tarInfo.linkname   , # 8
-                tarInfo.uid        , # 9
-                tarInfo.gid        , # 10
-                isTar              , # 11
-                tarInfo.issparse() , # 12
-            )
-            self._setFileInfo( fileInfo )
+                path, name = fullPath.rsplit( "/", 1 )
+                fileInfo = (
+                    path               , # 0
+                    name               , # 1
+                    globalOffsetHeader , # 2
+                    globalOffset       , # 3
+                    tarInfo.size       , # 4
+                    tarInfo.mtime      , # 5
+                    mode               , # 6
+                    tarInfo.type       , # 7
+                    tarInfo.linkname   , # 8
+                    tarInfo.uid        , # 9
+                    tarInfo.gid        , # 10
+                    isTar              , # 11
+                    tarInfo.issparse() , # 12
+                )
+                self._setFileInfo( fileInfo )
         except tarfile.ReadError as e:
             if 'unexpected end of data' in str( e ):
                 print( "[Warning] The TAR file is incomplete. Ratarmount will work but some files might be cut off. "
@@ -732,13 +743,13 @@ class SQLiteIndexedTar:
             # its attributes.
             rows = self.sqlConnection.execute( 'SELECT * FROM "files" WHERE "path" == (?)',
                                                ( fullPath.rstrip( '/' ), ) )
-            dir = {}
+            directory = {}
             gotResults = False
             for row in rows:
                 gotResults = True
                 if row['name']:
-                    dir[row['name']] = self._rowToFileInfo( row )
-            return dir if gotResults else None
+                    directory[row['name']] = self._rowToFileInfo( row )
+            return directory if gotResults else None
 
         path, name = fullPath.rsplit( '/', 1 )
         row = self.sqlConnection.execute(
@@ -775,7 +786,7 @@ class SQLiteIndexedTar:
         try:
             self.sqlConnection.execute( 'INSERT OR REPLACE INTO "files" VALUES (' +
                                         ','.join( '?' * len( row ) ) + ');', row )
-        except UnicodeEncodeError as e:
+        except UnicodeEncodeError:
             print( "[Warning] Problem caused by file name encoding when trying to insert this row:", row )
             print( "[Warning] The file name will now be stored with the bad character being escaped" )
             print( "[Warning] instead of being correctly interpreted." )
@@ -879,20 +890,25 @@ class SQLiteIndexedTar:
                 print( "[Warning] Please recreate the index if you have problems with those." )
 
             if 'metadata' in tables:
-                values = dict( list( self.sqlConnection.execute( 'SELECT * FROM metadata;' ) ) )
+                values = dict( self.sqlConnection.execute( 'SELECT * FROM metadata;' ) )
                 if 'tarstats' in values:
                     values = json.loads( values['tarstats'] )
                 tarStats = os.stat( self.tarFileName )
 
-                if hasattr( tarStats, "st_size" ) and 'st_size' in values \
-                   and tarStats.st_size != values['st_size']:
+                if (
+                    hasattr( tarStats, "st_size" )
+                    and 'st_size' in values
+                    and tarStats.st_size != values['st_size']
+                ):
                     raise Exception( "TAR file for this SQLite index has changed size from",
                                      values['st_size'], "to", tarStats.st_size)
 
-                if self.verifyModificationTime \
-                   and hasattr( tarStats, "st_mtime" ) \
-                   and 'st_mtime' in values \
-                   and tarStats.st_mtime != values['st_mtime']:
+                if (
+                    self.verifyModificationTime
+                    and hasattr( tarStats, "st_mtime" )
+                    and 'st_mtime' in values
+                    and tarStats.st_mtime != values['st_mtime']
+                ):
                     raise Exception( "The modification date for the TAR file", values['st_mtime'],
                                      "to this SQLite index has changed (" + str( tarStats.st_mtime ) + ")" )
 
@@ -971,10 +987,10 @@ class SQLiteIndexedTar:
                 if compression == 'bz2' and 'IndexedBzip2File' not in globals():
                     raise Exception( "Can't open a bzip2 compressed TAR file '{}' without indexed_bzip2 module!"
                                      .format( name ) )
-                elif compression == 'gz' and 'IndexedGzipFile' not in globals():
+                if compression == 'gz' and 'IndexedGzipFile' not in globals():
                     raise Exception( "Can't open a bzip2 compressed TAR file '{}' without indexed_gzip module!"
                                      .format( name ) )
-                elif compression == 'xz' and 'lzmaffi' not in globals():
+                if compression == 'xz' and 'lzmaffi' not in globals():
                     raise Exception( "Can't open xz compressed TAR file '{}' without lzmaffi module!"
                                      .format( name ) )
 
@@ -983,7 +999,7 @@ class SQLiteIndexedTar:
 
                 return isTar, compression
 
-            except tarfile.ReadError as e:
+            except tarfile.ReadError:
                 if oldOffset is not None:
                     fileobj.seek( oldOffset )
 
@@ -1039,7 +1055,7 @@ class SQLiteIndexedTar:
             try:
                 offsets = dict( db.execute( 'SELECT blockoffset,dataoffset FROM bzip2blocks;' ) )
                 fileObject.set_block_offsets( offsets )
-            except Exception as e:
+            except:
                 if printDebug >= 2:
                     print( "[Info] Could not load BZip2 Block offset data. Will create it from scratch." )
 
@@ -1112,7 +1128,7 @@ class SQLiteIndexedTar:
                 print( "[Info] the index file location. The gzipindex size takes roughly 32kiB per 4MiB of" )
                 print( "[Info] uncompressed(!) bytes (0.8% of the uncompressed data) by default." )
                 raise Exception( "[Error] Could not initialize the GZip seek cache." )
-            elif printDebug >= 2:
+            if printDebug >= 2:
                 print( "Exported GZip index size:", os.stat( gzindex ).st_size )
 
             # Store contents of temporary file into the SQLite database
@@ -1169,10 +1185,13 @@ class TarMount( fuse.Operations ):
         # make the mount point read only and executable if readable, i.e., allow directory listing
         tarStats = os.stat( pathToMount[0] )
         # clear higher bits like S_IFREG and set the directory bit instead
-        mountMode = ( tarStats.st_mode & 0o777 ) | stat.S_IFDIR
-        if mountMode & stat.S_IRUSR != 0: mountMode |= stat.S_IXUSR
-        if mountMode & stat.S_IRGRP != 0: mountMode |= stat.S_IXGRP
-        if mountMode & stat.S_IROTH != 0: mountMode |= stat.S_IXOTH
+        mountMode = (
+            ( tarStats.st_mode & 0o777 )
+            | stat.S_IFDIR
+            | ( stat.S_IXUSR if tarStats.st_mode & stat.S_IRUSR != 0 else 0 )
+            | ( stat.S_IXGRP if tarStats.st_mode & stat.S_IRGRP != 0 else 0 )
+            | ( stat.S_IXOTH if tarStats.st_mode & stat.S_IROTH != 0 else 0 )
+        )
 
         self.rootFileInfo = SQLiteIndexedTar.FileInfo(
             offset       = None             ,
@@ -1411,7 +1430,7 @@ class TarMount( fuse.Operations ):
                 return self.getattr( targetLink, fh )
 
         # dictionary keys: https://pubs.opengroup.org/onlinepubs/007904875/basedefs/sys/stat.h.html
-        statDict = dict( ( "st_" + key, getattr( fileInfo, key ) ) for key in ( 'size', 'mtime', 'mode', 'uid', 'gid' ) )
+        statDict = { "st_" + key : getattr( fileInfo, key ) for key in ( 'size', 'mtime', 'mode', 'uid', 'gid' ) }
         # signal that everything was mounted read-only
         statDict['st_mode'] &= ~( stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH )
         statDict['st_mtime'] = int( statDict['st_mtime'] )
@@ -1502,7 +1521,7 @@ class TarMount( fuse.Operations ):
         try:
             mountSource.tarFileObject.seek( fileInfo.offset + offset, os.SEEK_SET )
             return mountSource.tarFileObject.read( length )
-        except RuntimeError as e:
+        except RuntimeError:
             traceback.print_exc()
             print( "Caught exception when trying to read data from underlying TAR file! Returning errno.EIO." )
             raise fuse.FuseOSError( fuse.errno.EIO )
@@ -1520,7 +1539,7 @@ class TarFileType:
 
     def __call__( self, tarFile ):
         if not os.path.exists( tarFile ):
-            return
+            raise argparse.ArgumentTypeError( "File '{}' does not exist!" )
 
         for compression in self.compressions:
             try:
@@ -1730,7 +1749,7 @@ version, you can simply do:
         args.mount_source = args.mount_source[:-1]
     if not args.mount_source:
         print( "[Error] You must at least specify one path to a valid TAR file or union mount source directory!" )
-        exit( 1 )
+        sys.exit( 1 )
 
     # Manually check that all specified TARs and folders exist
     compressions = [ '' ]

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open( os.path.join( scriptPath, 'README.md' ), encoding = 'utf-8' ) as file
 
 setup(
     name             = 'ratarmount',
-    version          = '0.6.1',
+    version          = '0.7.0',
 
     description      = 'Random Access Read-Only Tar Mount',
     url              = 'https://github.com/mxmlnkn/ratarmount',

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     long_description_content_type = 'text/markdown',
 
     py_modules       = [ 'ratarmount' ],
-    install_requires = [ 'fusepy', 'indexed_gzip', 'indexed_bzip2>=1.1.2' ],
+    install_requires = [ 'fusepy', 'indexed_gzip', 'indexed_bzip2>=1.1.2', 'lzmaffi' ],
     extras_require   = {
                             'legacy-serializers' : [
                                 'lz4',

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     long_description_content_type = 'text/markdown',
 
     py_modules       = [ 'ratarmount' ],
-    install_requires = [ 'fusepy', 'indexed_gzip', 'indexed_bzip2>=1.1.2', 'lzmaffi' ],
+    install_requires = [ 'fusepy', 'indexed_gzip', 'indexed_bzip2>=1.1.2', 'lzmaffi', 'indexed_zstd' ],
     extras_require   = {
                             'legacy-serializers' : [
                                 'lz4',

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -491,7 +491,11 @@ checkTarEncoding()
 
 python3 tests/tests.py || returnError "tests/tests.py"
 
-pylint --disable=C0326,C0103 ratarmount.py > pylint.log
+pylint --disable=C0326,C0103,C0330,W0702,W0703 --max-line-length=120 ratarmount.py | tee pylint.log
+if 'grep' -q ': E[0-9]{4}: ' pylint.log; then
+    echoerr 'There were warnings during the pylint run!'
+    exit 1
+fi
 
 rm -f tests/*.index.*
 


### PR DESCRIPTION
Adds support for seeking in xz compressed TARs and single files. If those xz files actually contain more than one block, then seeking will actually be faster than simply decoding the file from the beginning.

Closes #41 