### PR TITLE
Pin indexed_gzip version to 1.5.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fusepy
-indexed_gzip>=1.5.3
+indexed_gzip==1.4.0
 indexed_bzip2>=1.1.2
 indexed_zstd>=1.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fusepy
-indexed_gzip
+indexed_gzip>=1.5.3
 indexed_bzip2>=1.1.2
 indexed_zstd>=1.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fusepy
-indexed_gzip==1.4.0
+indexed_gzip==1.5.3
 indexed_bzip2>=1.1.2
 indexed_zstd>=1.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fusepy
-indexed_gzip==1.5.3
+indexed_gzip>=1.5.3
 indexed_bzip2>=1.1.2
 indexed_zstd>=1.2.2


### PR DESCRIPTION
Pin indexed_gzip version to 1.5.3. Version 1.5.3 introduces support for file-like objects that aren't backed by a fileno (see https://github.com/pauldmccarthy/indexed_gzip/releases). This change is needed for ratarmount to support file-like objects when using .gz files.