### PR TITLE
Fix CI by using ubuntu-18.04

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         # Oldest and newest versions should be enough. Python versions are supported 5 years from release date.

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   deploy:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Fix CI by using ubuntu-18.04 -- GitHub Actions recently upgraded default versions of ubuntu to ubuntu-20.04. This probably upgraded libfuse and caused the errors seen in #58.