### PR TITLE
Print out logs to CI when tests fail

### DIFF
--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -129,6 +129,10 @@ returnError()
     echoerr -e "\e[37m${FUNCNAME[1]}$lineNumber <- ${FUNCNAME[*]:2}\e[0m"
     echoerr -e "\e[37m$message\e[0m"
     echoerr -e '\e[31mTEST FAILED!\e[0m'
+    echo "ratarmount.stdout.log:"
+    cat ratarmount.stdout.log
+    echo "ratarmount.stderr.log:"
+    cat ratarmount.stderr.log
     exit 1
 }
 


### PR DESCRIPTION
Branching out of #58. I think this feature is useful to just always have enabled, so it's easier to debug CI failures.