### PR TITLE
Support file objects without a fileno for .tar.gz files

### DIFF
--- a/ratarmount.py
+++ b/ratarmount.py
@@ -374,6 +374,9 @@ class SQLiteIndexedTar:
                 raise ValueError("At least one of tarFileName and fileObject arguments should be set!")
             self.tarFileName = os.path.abspath(tarFileName) if tarFileName else '<file object>'
             fileObject = open(self.tarFileName, 'rb')
+        elif tarFileName:
+            # If tarFileName was specified for a file object, set self.tarFileName accordingly.
+            self.tarFileName = tarFileName
 
         fileObject.seek(0, io.SEEK_END)
         fileSize = fileObject.tell()
@@ -748,7 +751,10 @@ class SQLiteIndexedTar:
                 pass
 
         if progressBar is None:
-            progressBar = ProgressBar(os.fstat(fileObject.fileno()).st_size)
+            try:
+                progressBar = ProgressBar(os.fstat(fileObject.fileno()).st_size)
+            except io.UnsupportedOperation:
+                pass
 
         # 3. Iterate over files inside TAR and add them to the database
         try:
@@ -870,7 +876,12 @@ class SQLiteIndexedTar:
         # so check stream offset.
         fileCount = self.sqlConnection.execute('SELECT COUNT(*) FROM "files";').fetchone()[0]
         if fileCount == 0:
-            tarInfo = os.fstat(fileObject.fileno())
+            try:
+                tarInfo = os.fstat(fileObject.fileno())
+            except io.UnsupportedOperation:
+                # If fileObject doesn't have a fileno, we set tarInfo to None
+                # and set the relevant statistics (such as st_mtime) to sensible defaults.
+                tarInfo = None
             fname = os.path.basename(self.tarFileName)
             for suffix in ['.gz', '.bz2', '.bzip2', '.gzip', '.xz', '.zst', '.zstd']:
                 if fname.lower().endswith(suffix) and len(fname) > len(suffix):
@@ -886,17 +897,17 @@ class SQLiteIndexedTar:
 
             # fmt: off
             fileInfo = (
-                ""                 ,  # 0 path
-                fname              ,  # 1
-                None               ,  # 2 header offset
-                0                  ,  # 3 data offset
-                fileSize           ,  # 4
-                tarInfo.st_mtime   ,  # 5
-                tarInfo.st_mode    ,  # 6
-                None               ,  # 7 TAR file type. Currently unused but overlaps with mode anyways
-                None               ,  # 8 linkname
-                tarInfo.st_uid     ,  # 9
-                tarInfo.st_gid     ,  # 10
+                ""                                          ,  # 0 path
+                fname                                       ,  # 1
+                None                                        ,  # 2 header offset
+                0                                           ,  # 3 data offset
+                fileSize                                    ,  # 4
+                tarInfo.st_mtime if tarInfo else 0          ,  # 5
+                tarInfo.st_mode if tarInfo else 0o444       ,  # 6
+                None                                        ,  # 7 TAR file type. Currently unused but overlaps with mode anyways
+                None                                        ,  # 8 linkname
+                tarInfo.st_uid if tarInfo else 0            ,  # 9
+                tarInfo.st_gid if tarInfo else 0            ,  # 10
                 False              ,  # 11 isTar
                 False              ,  # 12 isSparse, don't care if it is actually sparse or not because it is not in TAR
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fusepy
-indexed_gzip
+indexed_gzip>=1.5.3
 indexed_bzip2>=1.1.2
 indexed_zstd>=1.2.2

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -4,12 +4,15 @@
 import io
 import os
 import sys
+import gzip
+import tarfile
 import tempfile
 
 if __name__ == '__main__' and __package__ is None:
     sys.path.insert( 0, os.path.abspath( os.path.join( os.path.dirname(__file__) , '..' ) ) )
 
 import ratarmount
+from ratarmount import FileInfo, SQLiteIndexedTar
 
 testData = b"1234567890"
 tmpFile = tempfile.TemporaryFile()
@@ -73,3 +76,104 @@ assert stenciledFile.tell() == 26
 assert stenciledFile.read( 1 ) == b""
 assert stenciledFile.seek( -6, io.SEEK_END ) == 0
 assert stenciledFile.read( 1 ) == b"2"
+
+print("Test creating and using an index with .tar.gz files with SQLiteIndexedTar")
+
+def writestr(tf, name, contents):
+    tinfo = tarfile.TarInfo(name)
+    tinfo.size = len(contents)
+    tf.addfile(tinfo, io.BytesIO(contents.encode()))
+
+def writedir(tf, name):
+    tinfo = tarfile.TarInfo(name)
+    tinfo.type = tarfile.DIRTYPE
+    tf.addfile(tinfo, io.BytesIO())
+
+with tempfile.NamedTemporaryFile(
+    suffix=".tar.gz"
+) as tmp_tar_file, tempfile.NamedTemporaryFile(
+    suffix=".sqlite"
+) as tmp_index_file:
+    with tarfile.open(name=tmp_tar_file.name, mode="w:gz") as tf:
+        writestr(tf, "./README.md", "hello world")
+        writedir(tf, "./src")
+        writestr(tf, "./src/test.sh", "echo hi")
+        writedir(tf, "./dist")
+        writedir(tf, "./dist/a")
+        writedir(tf, "./dist/a/b")
+        writestr(tf, "./dist/a/b/test2.sh", "echo two")
+    
+    kwargs_set = {
+        "\tTest with file paths": dict(fileObject=None, tarFileName=tmp_tar_file.name),
+        "\tTest with file objects": dict(fileObject=open(tmp_tar_file.name, "rb"), tarFileName="tarFileName"),
+        "\tTest with file objects with no fileno": dict(fileObject=io.BytesIO(open(tmp_tar_file.name, "rb").read()), tarFileName="tarFileName")
+    }
+
+    for name, kwargs in kwargs_set.items():
+        print(name)
+        # Create index
+        SQLiteIndexedTar(
+            **kwargs,
+            writeIndex=True,
+            clearIndexCache=True,
+            indexFileName=tmp_index_file.name,
+        )
+        # Read from index
+        indexed_file = SQLiteIndexedTar(
+            **kwargs,
+            writeIndex=False,
+            clearIndexCache=False,
+            indexFileName=tmp_index_file.name,
+        )
+        finfo = indexed_file.getFileInfo("/src/test.sh")
+        assert finfo.type == tarfile.REGTYPE
+        assert indexed_file.read(path="/src/test.sh", size=finfo.size, offset=0) == b"echo hi"
+        finfo = indexed_file.getFileInfo("/dist/a")
+        assert finfo.type == tarfile.DIRTYPE
+        assert indexed_file.getFileInfo("/dist/a", listDir=True) == {'b': ratarmount.FileInfo(offsetheader=3584, offset=4096, size=0, mtime=0, mode=16804, type=b'5', linkname='', uid=0, gid=0, istar=0, issparse=0)}
+        assert indexed_file.getFileInfo("/", listDir=True) == {'README.md': FileInfo(offsetheader=0, offset=512, size=11, mtime=0, mode=33188, type=b'0', linkname='', uid=0, gid=0, istar=0, issparse=0), 'dist': FileInfo(offsetheader=2560, offset=3072, size=0, mtime=0, mode=16804, type=b'5', linkname='', uid=0, gid=0, istar=0, issparse=0), 'src': FileInfo(offsetheader=1024, offset=1536, size=0, mtime=0, mode=16804, type=b'5', linkname='', uid=0, gid=0, istar=0, issparse=0)}
+        finfo = indexed_file.getFileInfo("/README.md")
+        assert finfo.size == 11
+        assert indexed_file.read("/README.md", size=11, offset=0) == b"hello world"
+        assert indexed_file.read("/README.md", size=3, offset=3) == b"lo "
+
+print("Test creating and using an index with .gz files with SQLiteIndexedTar")
+
+with tempfile.NamedTemporaryFile(
+    suffix=".gz"
+) as tmp_tar_file, tempfile.NamedTemporaryFile(
+    suffix=".sqlite"
+) as tmp_index_file:
+    with gzip.open(tmp_tar_file.name, "wb") as f:
+        f.write(b"hello world")
+    
+    kwargs_set = {
+        "\tTest with file paths": dict(fileObject=None, tarFileName=tmp_tar_file.name),
+        "\tTest with file objects": dict(fileObject=open(tmp_tar_file.name, "rb"), tarFileName="tarFileName"),
+        "\tTest with file objects with no fileno": dict(fileObject=io.BytesIO(open(tmp_tar_file.name, "rb").read()), tarFileName="tarFileName")
+    }
+
+    for name, kwargs in kwargs_set.items():
+        print(name)
+        # Create index
+        SQLiteIndexedTar(
+            **kwargs,
+            writeIndex=True,
+            clearIndexCache=True,
+            indexFileName=tmp_index_file.name,
+        )
+        # Read from index
+        indexed_file = SQLiteIndexedTar(
+            **kwargs,
+            writeIndex=False,
+            clearIndexCache=False,
+            indexFileName=tmp_index_file.name,
+        )
+        expected_name = os.path.basename(tmp_tar_file.name)[:-3] if kwargs["fileObject"] is None else "tarFileName"
+        finfo = indexed_file.getFileInfo("/", listDir=True)
+        assert expected_name in finfo
+        assert finfo[expected_name].size == 11
+        finfo = indexed_file.getFileInfo("/" + expected_name)
+        assert finfo.size == 11
+        assert indexed_file.read("/" + expected_name, size=11, offset=0) == b"hello world"
+        assert indexed_file.read("/" + expected_name, size=3, offset=3) == b"lo "


### PR DESCRIPTION
This issue fixes https://github.com/mxmlnkn/ratarmount/issues/52, so that I can read from / create an index for a tar file object without a fileno. Also bumps the dependency indexed_gzip>=1.5.3.

Also adds tests for the ratarmount API to ensure file object support doesn't regress.
