### PR TITLE
Transform password cli argument to bytes type

### DIFF
--- a/.github/workflows/BuildAppImage.yml
+++ b/.github/workflows/BuildAppImage.yml
@@ -1,0 +1,129 @@
+name: Build-AppImage
+
+on:
+  workflow_dispatch:
+
+jobs:
+
+  Manylinux-Appimage:
+    runs-on: ubuntu-latest
+    container: quay.io/pypa/manylinux2014_x86_64
+    env:
+      appbase: ratarmount-manylinux2014_x86_64
+      appdir: ratarmount-manylinux2014_x86_64.AppDir
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Print System Information
+      run: |
+        echo "uname -a: $( uname -a )"
+        cat /etc/issue
+        echo "Shell: $SHELL"
+        echo "Mount points:"; mount
+
+    - name: Install System Build Tools
+      run: |
+        ln -s /opt/python/cp39-cp39/bin/python3 /usr/local/bin/python3
+        export PATH="/opt/python/cp39-cp39/bin:$PATH"
+        python3 -m pip install python-appimage
+        yum install -y fuse fakeroot patchelf fuse-libs libsqlite3x strace desktop-file-utils
+
+    - name: Install AppImage Tooling
+      run: |
+        curl -L -o /usr/bin/appimagetool 'https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage'
+        chmod u+x /usr/bin/appimagetool
+        curl -L -o /usr/bin/linuxdeploy 'https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage'
+        chmod u+x /usr/bin/linuxdeploy
+
+    - name: Build Base Python AppImage With Ratarmount Metadata
+      run: |
+        python3 -m python_appimage build app -l manylinux2014_x86_64 -p 3.9 AppImage/
+
+    - name: Extract AppImage to AppDir for Further Modification
+      run: |
+        ./ratarmount-x86_64.AppImage --appimage-extract
+        mv squashfs-root/ "$appdir"
+
+    - name: Install Ratarmount into AppDir
+      run: |
+        "$appdir/opt/python3.9/bin/python3.9" -I -m pip install --no-cache-dir ./core
+        "$appdir/opt/python3.9/bin/python3.9" -I -m pip install --no-cache-dir .
+
+    - name: Bundle System Dependencies into AppDir
+      run: |
+        # Note that manylinux2014 already has libsqlite3.so.0 inside /usr/lib.
+        cp -a $( repoquery -l fuse-libs | 'grep' 'lib64.*[.]so' ) "$appdir"/usr/lib/
+        APPIMAGE_EXTRACT_AND_RUN=1 linuxdeploy --appdir="$appdir" \
+            --library=/usr/lib64/libfuse.so.2 \
+            --library=/usr/lib64/libulockmgr.so.1 \
+            --executable=/usr/bin/fusermount \
+            --executable=/usr/bin/ulockmgr_server
+
+    - name: Clean up Unnecessary Files from AppDir
+      run: |
+        "$appdir/opt/python3.9/bin/python3.9" -s -m pip uninstall -y build setuptools wheel pip
+        rm -rf "$appdir/opt/python3.9/lib/python3.9/site-packages/indexed_gzip/tests" \
+               "$appdir/opt/python3.9/include" \
+               "$appdir/usr/share/tcltk" \
+               "$appdir/usr/lib/libtk8.5.so" \
+               "$appdir/usr/lib/libtcl8.5.so" \
+               "$appdir/opt/python3.9/lib/python3.9/ensurepip" \
+               "$appdir/opt/python3.9/lib/python3.9/lib2to3" \
+               "$appdir/opt/python3.9/lib/python3.9/tkinter" \
+               "$appdir/opt/python3.9/lib/python3.9/unittest"
+        find "$appdir" -type d -empty -print0 | xargs -0 rmdir
+        find "$appdir" -type d -empty -print0 | xargs -0 rmdir
+        find "$appdir" -name '__pycache__' -print0 | xargs -0 rm -r
+
+    - name: Create AppImage from Modified AppDir
+      run: |
+        APPIMAGE_EXTRACT_AND_RUN=1 ARCH=x86_64 appimagetool --no-appstream "$appbase".App{Dir,Image}
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: ratarmount-manylinux2014_x86_64.AppImage
+        path: ratarmount-manylinux2014_x86_64.AppImage
+
+
+  AppImage-Tests:
+    runs-on: ${{ matrix.os }}
+    needs: [Manylinux-Appimage]
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: ratarmount-manylinux2014_x86_64.AppImage
+
+    - name: Install AppImage
+      run: |
+        chmod u+x ratarmount-manylinux2014_x86_64.AppImage
+        mv ratarmount-manylinux2014_x86_64.AppImage /usr/local/bin/ratarmount
+        echo "/usr/local/bin" >> $GITHUB_PATH
+
+    - name: Install Dependencies
+      run: |
+        # These are required for creating test files on the fly not for ratarmount!
+        sudo apt-get -y install bzip2 pixz zstd unar
+
+    - name: Test Simple Startup
+      run: |
+        ratarmount --help
+        ratarmount --version
+
+    - uses: actions/checkout@v2
+
+    - name: Test Simple Mount
+      run: |
+        ratarmount tests/single-file.tar mimi
+        ls -la mimi
+        sleep 1s
+        ratarmount -u mimi
+
+    - name: Regression Tests
+      run: |
+        export RATARMOUNT_CMD=/usr/local/bin/ratarmount
+        bash tests/runtests.sh

--- a/ratarmount.py
+++ b/ratarmount.py
@@ -1190,7 +1190,7 @@ seeking capabilities when opening that file.
     # Sanitize different ways to specify passwords into a simple list
     args.passwords = []
     if args.password:
-        args.passwords.append(args.password)
+        args.passwords.append(args.password.encode())
 
     if args.password_file:
         with open(args.password_file, 'rb') as file:

--- a/ratarmount.py
+++ b/ratarmount.py
@@ -984,6 +984,11 @@ seeking capabilities when opening that file.
         help = 'When used with recursively bind-mounted folders, TAR files inside the mounted folder will only be '
                'mounted on first access to it.' )
 
+    parser.add_argument(
+        '-e', '--eager', action='store_true', default = False,
+        help = 'When used with lazy option, mount archives on the firts level eagerly '
+               'without waiting for first access.' )
+
     # Considerations for the default value:
     #   - seek times for the bz2 backend are between 0.01s and 0.1s
     #   - seek times for the gzip backend are roughly 1/10th compared to bz2 at a default spacing of 4MiB
@@ -1442,6 +1447,7 @@ def cli(rawArgs: Optional[List[str]] = None) -> None:
         indexFilePath                = args.index_file,
         indexFolders                 = args.index_folders,
         lazyMounting                 = args.lazy,
+        eagerFlag                    = args.eager,
         passwords                    = args.passwords,
         parallelization              = args.parallelization,
         isGnuIncremental             = args.gnu_incremental,


### PR DESCRIPTION
The current version have a problem with opening password protected .zip files if the password was specified
using **--password** cli argument because ZipFile **open** and **setpassword** methods expect the password to have **bytes** type and  not **str**.