### PR TITLE
fixed TypeError on RarMountSource info.datetime

### DIFF
--- a/core/ratarmountcore/RarMountSource.py
+++ b/core/ratarmountcore/RarMountSource.py
@@ -129,9 +129,12 @@ class RarMountSource(MountSource):
     @staticmethod
     def _convertToFileInfo(info: "rarfile.RarInfo") -> FileInfo:
         mode = 0o555 | (stat.S_IFDIR if info.is_dir() else stat.S_IFREG)
-        dtime = datetime.datetime(*info.date_time)
-        dtime = dtime.replace(tzinfo=datetime.timezone.utc)
-        mtime = dtime.timestamp() if info.date_time else 0
+        if info.date_time:
+            dtime = datetime.datetime(*info.date_time)
+            dtime = dtime.replace(tzinfo=datetime.timezone.utc)
+            mtime = dtime.timestamp() if info.date_time else 0
+        else:
+            mtime = 0
 
         # file_redir is (type, flags, target) or None. Only tested for type == RAR5_XREDIR_UNIX_SYMLINK.
         linkname = ""


### PR DESCRIPTION
I came across a rar file where the contained files did not
have a timestamp. This resulted in:

  File "/home/rizzle/.local/lib/python3.9/site-packages/ratarmountcore/RarMountSource.py", line 132, in _convertToFileInfo
    dtime = datetime.datetime(*info.date_time)
TypeError: datetime.datetime() argument after * must be an iterable, not NoneType