### PR TITLE
Small docs fix

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -109,7 +109,7 @@ The factory function `open` opens one of the archive `MountSource` implementatio
 ## Example
 
 ```Python3
-from ratarmountcore.factory import open_mount_source
+from ratarmountcore.mountsource.factory import open_mount_source
 
 archive = open_mount_source("foo.tar", recursive=True)
 print(archive.list("/"))

--- a/core/ratarmountcore/mountsource/__init__.py
+++ b/core/ratarmountcore/mountsource/__init__.py
@@ -38,7 +38,7 @@ reimports, ergo you should specify the full module hierarchy for imports.
 Example:
 
     from ratarmountcore.mountsource.formats.tar import SQLiteIndexedTar
-    from ratarmountcore.factory import open_mount_source
+    from ratarmountcore.mountsource.factory import open_mount_source
 
     archive = SQLiteIndexedTar("foo.tar")
     # or alternatively:


### PR DESCRIPTION
This project looks great. As I was starting to use it I noticed an issue in your example in the core readme.

https://github.com/mxmlnkn/ratarmount/blob/0db086ad8a769d442ceadf1e79294c16ca96bcde/core/README.md?plain=1#L109-L121


When I run it I see the following:
```python
>>> from ratarmountcore.factory import open_mount_source
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'ratarmountcore.factory'
```

Based on other examples it seems that it should be `ratarmountcore.mountsource.factory`

https://github.com/mxmlnkn/ratarmount/blob/0db086ad8a769d442ceadf1e79294c16ca96bcde/core/ratarmountcore/mountsource/compositing/automount.py#L10

This PR updates the two places where this appears in your documentation.