### PR TITLE
Fix --version --oss-attributions-short to avoid sending network requests.

### DIFF
--- a/ratarmount/cli.py
+++ b/ratarmount/cli.py
@@ -71,7 +71,7 @@ class PrintOSSAttributionAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         from .dependencies import print_oss_attributions
 
-        print_oss_attributions()
+        print_oss_attributions(with_licenses=True)
         parser.exit()
 
 


### PR DESCRIPTION
Currently, usage of `--version` and `--oss-attributions-short ` will make unnecessary network connection.

On an air gapped environment or if Github is down this may cause program to hang, especially since no timeout is speciffied on network connection opening.

This PR ensure
* These network connections are only made when `--oss-attributions` is used
* Network connection will not hang and not make program crash if network is unreachable (command execution will still be long as DNS requests timeout can't be specified)

Thanks for your work.